### PR TITLE
Use Mojo::UserAgent instead of LWP::UserAgent

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -67,10 +67,9 @@ my %WriteMakefile = (
 		},
 
 	'PREREQ_PM'     => {
-		'HTTP::Request'         => '1.28',
 		'HTTP::Status'          => '0',
-		'LWP::UserAgent'        => '1.09',
-		'LWP::Protocol::https'  => '1',
+		'IO::Socket::SSL'       => '1.94',
+		'Mojo::UserAgent'       => '0',
 		},
 
 	'META_MERGE' => {

--- a/t/403.t
+++ b/t/403.t
@@ -1,6 +1,7 @@
 use Test::More tests => 1;
 
 use HTTP::SimpleLinkChecker;
+HTTP::SimpleLinkChecker::user_agent->max_redirects(5);
 
 my $code = HTTP::SimpleLinkChecker::check_link(
 	'http://www.pair.com/comdog/cgi-bin/403.cgi');

--- a/t/user_agent.t
+++ b/t/user_agent.t
@@ -5,10 +5,10 @@ use_ok( 'HTTP::SimpleLinkChecker' );
 ok( defined &HTTP::SimpleLinkChecker::user_agent );
 
 my $UA = &HTTP::SimpleLinkChecker::user_agent();
-isa_ok( $UA, 'LWP::UserAgent');
+isa_ok( $UA, 'Mojo::UserAgent');
 
-like( $UA->agent, qr/libwww-perl/ );
+like( $UA->transactor->name, qr/Mojolicious/ );
 
 my $new_name = "brian's link checker";
-$UA->agent( $new_name );
-is( $UA->agent, $new_name );
+$UA->transactor->name( $new_name );
+is( $UA->transactor->name, $new_name );


### PR DESCRIPTION
In the spirit of Hacktoberfest, I decided to take a look at #1.

I am not too familiar with the whole CPAN author process, so beware of any rookie mistakes I may have made. It does pass all tests on my end, however. :)

The pull request breaks the interface of user_agent(), in that it now is of type Mojo::UserAgent
instead of LWP::UserAgent.